### PR TITLE
don't use custom autoreconf phase but add extra args

### DIFF
--- a/packages/ctemplate/package.py
+++ b/packages/ctemplate/package.py
@@ -33,8 +33,7 @@ class Ctemplate(AutotoolsPackage):
     depends_on('python@:2', type='build', when='@:2.3')
     depends_on('python@3:', type='build', when='@2.4:')
 
-    def autoreconf(self, spec, prefix):
-        which('bash')('autoreconf --force --install --warnings all,no-obsolete')
+    autoreconf_extra_args = ["--warnings","all,no-obsolete"]
 
     def install(self, spec, prefix):
         configure("--prefix=" + prefix)


### PR DESCRIPTION
ctemplate, dependency of hemepure does not compile.

We are trying to use a custom autoreconf phase but the argument `autoreconf --force --install --warnings all,no-obsolete` is interpreted as a script that doesn't exist.
Following the [doc](https://spack.readthedocs.io/en/latest/build_systems/autotoolspackage.html) I propose this PR if we really need to change the default options