### PR TITLE
fix hemeXtract linking with rpc

### DIFF
--- a/packages/hemeXtract/hemeXtract.patch
+++ b/packages/hemeXtract/hemeXtract.patch
@@ -15,10 +15,10 @@ index 22ff3f5..183c0bb 100644
 +SRC=hemeXtract.cc
 +
 +hemeXtract: $(SRC)
-+	$(CXX) $(CXXFLAGS) -o $@ $<
++	$(CXX) $(CXXFLAGS) -o $@ $< -ltirpc
 +
 +debug: $(SRC)
-+	$(CXX) $(CXXFLAGS_DEBUG) -o $@ $<
++	$(CXX) $(CXXFLAGS_DEBUG) -o $@ $< -ltirpc
 +
 +.phony: clean
 +clean:

--- a/packages/hemeXtract/package.py
+++ b/packages/hemeXtract/package.py
@@ -16,11 +16,6 @@ class Hemextract(MakefilePackage):
     # patch the Makefile
     patch('hemeXtract.patch')
 
-    build_targets = ['CC=cc']
-
-    # inject flags as make variables, i.e `make CXXFLAGS=<cxxflags>`
-    flag_handler = build_system_flags
-
     # installation step is missing in the Makefile
     def install(self, spec, prefix):
         mkdir(prefix.bin)


### PR DESCRIPTION
without this patch
````sh
38 errors found in build log:
  >> 6     hemeXtract.cc:(.text+0x89): undefined reference to `xdr_u_int'
  >> 7     /bin/ld: hemeXtract.cc:(.text+0x96): undefined reference to `xdr_u_int'
  >> 8     /bin/ld: hemeXtract.cc:(.text+0xa3): undefined reference to `xdr_u_int'
  >> 9     /bin/ld: hemeXtract.cc:(.text+0x10f): undefined reference to `xdr_float'
  >> 10    /bin/ld: hemeXtract.cc:(.text+0x1d4): undefined reference to `xdr_u_int'
  >> 11    /bin/ld: hemeXtract.cc:(.text+0x1e1): undefined reference to `xdr_u_int'
````